### PR TITLE
refactor:Add autoformat before commit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,107 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...

--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,13 @@ mbedtls_make:
 
 conn_http.o: connectivity/conn_http.c
 	@echo Compiling $@ ...
-	$(CC) -v -c $(CFLAGS) $(INCLUDES) -MMD -MF conn_http.c.d -o $@ $<
--include conn_http.c.d
+	$(CC) -v -c $(CFLAGS) $(INCLUDES) -o $@ $<
 
 main.o: main.c
 	@echo Compiling: $< ....
+	$(CC) -c $(CFLAGS) $(INCLUDES) -o $@ $<
+$(UTILS_OBJS):
 	$(MAKE) -C $(UTILS_PATH)
-	$(CC) -c $(CFLAGS) $(INCLUDES) -MMD -MF main.c.d -o $@ $<
 
 test: $(TEST_PATH)
 	$(MAKE) -C $(TEST_PATH)
@@ -86,4 +86,3 @@ clean_http_parser:
 
 pre-build:
 	git config core.hooksPath hooks
--include main.c.d

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,9 @@ CONNECTIVITY_OBJS = conn_http.o
 OBJS = main.o $(HTTP_PARSER_PATH)/http_parser.o $(UTILS_OBJS) $(CONNECTIVITY_OBJS)
 
 .SUFFIXES:.c .o
+.PHONY: pre-build
 
-all: ta_client
+all: pre-build ta_client
 
 ta_client: mbedtls_make $(OBJS)
 	@echo Linking: $@ ....
@@ -83,4 +84,6 @@ clean_mbedtls:
 clean_http_parser:
 	$(MAKE) -C $(HTTP_PARSER_PATH) clean
 
+pre-build:
+	git config core.hooksPath hooks
 -include main.c.d

--- a/hooks/formatter
+++ b/hooks/formatter
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for file in $(find $(git rev-parse --show-toplevel) | grep -E "\.(c|cc|cpp|h|hh|hpp|m|mm)\$" | grep -Ev "/mbedtls/|/third_party/")
+for file in $(find $(git rev-parse --show-toplevel) | grep -E "\.(c|cc|cpp|h|hh|hpp|m|mm)\$" | grep -Ev "/third_party/")
 do
   clang-format -style=file -fallback-style=none -i $file
 done

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# autoformat all *.c,*.h files before commit
+root=$(git rev-parse --show-toplevel)
+status=0
+for file in $(git diff --staged --name-only | grep -E "\.(c|cc|cpp|h|hh|hpp)\$")
+do
+  filepath="$root/$file"
+  output=$(diff <(cat $filepath) <(clang-format -style=file -fallback-style=none $filepath))
+  if [ $? -ne 0 ]
+  then
+    echo -e "\nFile \""$file"\" is not compliant with the coding style"
+    echo -e "Add your file again after autoformat"
+    echo -e "autoformat $file"
+    clang-format -style=file -fallback-style=none -i $file
+    status=1
+  fi
+done
+exit $status

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# This sample shows how to prevent push of commits where the log message starts
+# with "WIP" (work in progress).
+
+remote="$1"
+url="$2"
+
+z40=0000000000000000000000000000000000000000
+
+while read local_ref local_sha remote_ref remote_sha
+do
+	if [ "$local_sha" = $z40 ]
+	then
+		# Handle delete
+		:
+	else
+		if [ "$remote_sha" = $z40 ]
+		then
+			# New branch, examine all commits
+			range="$local_sha"
+		else
+			# Update to existing branch, examine new commits
+			range="$remote_sha..$local_sha"
+		fi
+
+		# Check for WIP commit
+		commit=`git rev-list -n 1 --grep '^WIP' "$range"`
+		if [ -n "$commit" ]
+		then
+			echo >&2 "Found WIP commit in $local_ref, not pushing"
+			exit 1
+		fi
+	fi
+done
+
+exit 0


### PR DESCRIPTION
This commit add clang format style from tangle-accerlator,
and autoformat the file which commited.

Closes #4