### PR TITLE
fix: Fix warning during compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CONNECTIVITY_PATH = $(ROOT_DIR)/connectivity
 export THIRD_PARTY_PATH ROOT_DIR UTILS_PATH MBEDTLS_PATH
 
 ifeq ($(DEBUG), n)
-CFLAGS = -Wall -fPIC -DHAVE_CONFIG_H -D_U_="__attribute__((unused))" -O2
+CFLAGS = -Wall -Werror -fPIC -DHAVE_CONFIG_H -D_U_="__attribute__((unused))" -O2
 else
 CFLAGS = -Wall -fPIC -DHAVE_CONFIG_H -D_U_="__attribute__((unused))" -g3 -DDEBUG
 endif

--- a/connectivity/conn_http.c
+++ b/connectivity/conn_http.c
@@ -115,8 +115,7 @@ http_retcode_t http_open(connect_info_t *const info, char const *const seed_nonc
   return RET_OK;
 }
 
-http_retcode_t http_send_request(connect_info_t *const info, const char const *req) {
-  http_retcode_t ret;
+http_retcode_t http_send_request(connect_info_t *const info, const char *req) {
   size_t req_len = strlen(req), write_len = 0, ret_len;
 
   while (write_len < req_len) {
@@ -133,6 +132,7 @@ http_retcode_t http_send_request(connect_info_t *const info, const char const *r
     }
     write_len += ret_len;
   }
+  return RET_OK;
 }
 
 http_retcode_t http_read_response(connect_info_t *const info, char *res, size_t res_len) {
@@ -157,6 +157,7 @@ http_retcode_t http_read_response(connect_info_t *const info, char *res, size_t 
     default:
       break;
   }
+  return RET_OK;
 }
 
 http_retcode_t http_close(connect_info_t *const info) {

--- a/connectivity/conn_http.h
+++ b/connectivity/conn_http.h
@@ -40,7 +40,7 @@ typedef struct {
 
 http_retcode_t http_open(connect_info_t *const info, char const *const seed_nonce, char const *const host,
                          char const *const port);
-http_retcode_t http_send_request(connect_info_t *const info, const char const *req);
+http_retcode_t http_send_request(connect_info_t *const info, const char *req);
 http_retcode_t http_read_response(connect_info_t *const info, char *res, size_t res_len);
 http_retcode_t http_close(connect_info_t *const info);
 

--- a/main.c
+++ b/main.c
@@ -76,7 +76,8 @@ int log_address(char *next_addr) {
   // Append the next address to the address log file
   fp = fopen(ADDR_LOG_PATH, "a");
   if (!fp) {
-    perror("open addr_log.log failed:") fclose(fp);
+    perror("open addr_log.log failed:");
+    fclose(fp);
     return -1;
   }
   snprintf(addr_log, 83, addr_log_template, next_addr);
@@ -98,7 +99,7 @@ int main(int argc, char *argv[]) {
     return -1;
   }
 #else
-  if (!log(address(next_addr))) {
+  if (log_address(next_addr)) {
     fprintf(stderr, "log address failed");
     return -1;
   }

--- a/tests/test_crypto_utils.c
+++ b/tests/test_crypto_utils.c
@@ -82,7 +82,7 @@ int main(void) {
 
   memset(ciphertext, 0, 1024);
   memset(plain, 0, 1024);
-  ciphertext_len = encrypt(test_payload2, test_paylen2, ciphertext, 1024, iv, private_key, id);
+  ciphertext_len = encrypt((char*)test_payload2, test_paylen2, ciphertext, 1024, iv, private_key, id);
   decrypt(ciphertext, ciphertext_len, plain, 1024, iv, private_key);
 
   /* compare payload */

--- a/utils/crypto_utils.c
+++ b/utils/crypto_utils.c
@@ -10,7 +10,7 @@
 
 // The device ID we are used here is IMSI. We could use other physical ID in the
 // future.
-int get_device_id(char *device_id) {
+int get_device_id(const char *device_id) {
   // TODO: replace cm command
   char result_buf[MAXLINE], *imsi;
   char cmd[] = "cm sim info";
@@ -29,7 +29,7 @@ int get_device_id(char *device_id) {
     }
   }
 
-  strncpy(device_id, imsi, IMSI_LEN);
+  strncpy((char *)device_id, imsi, IMSI_LEN);
 
   if (pclose(fp) == -1) {
     perror("close FILE pointer");
@@ -39,7 +39,7 @@ int get_device_id(char *device_id) {
 }
 
 // Get AES key with hashchain in legato originated app form.
-int get_aes_key(uint8_t *key) {
+int get_aes_key(const uint8_t *key) {
   // TODO: replace cm command
   char hash_chain_res[MAXLINE];
   char cmd[] = "cm sim info";
@@ -56,7 +56,7 @@ int get_aes_key(uint8_t *key) {
     hash_chain_res[strlen(hash_chain_res) - 2] = '\0';
   }
 
-  strncpy(key, hash_chain_res, AES_BLOCK_SIZE);
+  strncpy((char *)key, hash_chain_res, AES_BLOCK_SIZE);
 
   if (pclose(fp) == -1) {
     perror("close FILE pointer");
@@ -66,7 +66,7 @@ int get_aes_key(uint8_t *key) {
   return 0;
 }
 
-int aes_encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *key, unsigned int keybits,
+int aes_encrypt(const unsigned char *plaintext, int plaintext_len, const unsigned char *key, unsigned int keybits,
                 unsigned char iv[AES_BLOCK_SIZE], unsigned char *ciphertext, int ciphertext_len) {
   mbedtls_aes_context ctx;
   int status;
@@ -114,12 +114,12 @@ exit:
   return -1;
 }
 
-int aes_decrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *key, unsigned int keybits,
+int aes_decrypt(const unsigned char *ciphertext, int ciphertext_len, const unsigned char *key, unsigned int keybits,
                 unsigned char iv[AES_BLOCK_SIZE], unsigned char *plaintext, int plaintext_len) {
   mbedtls_aes_context ctx;
   int status, n = 0;
   char *err;
-  char buf[AES_BLOCK_SIZE];
+  uint8_t buf[AES_BLOCK_SIZE];
   /* Create and initialise the context */
   mbedtls_aes_init(&ctx);
   memset(plaintext, 0, plaintext_len);

--- a/utils/crypto_utils.h
+++ b/utils/crypto_utils.h
@@ -15,22 +15,19 @@
 extern "C" {
 #endif
 
-#define EXIT_SUCCESS 0
-#define EXIT_FAILURE -1
-
 #define AES_BLOCK_SIZE 16
 #define MAXLINE 1024
 #define IMSI_LEN 15
 
-int get_device_id(char *device_id);
-int get_aes_key(uint8_t *key);
+int get_device_id(const char *device_id);
+int get_aes_key(const uint8_t *key);
 int encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *ciphertext, int ciphertext_len, uint8_t iv[16],
             uint8_t key[AES_BLOCK_SIZE * 2], uint8_t device_id[IMSI_LEN + 1]);
 int decrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *plaintext, int plaintext_len, uint8_t iv[16],
             uint8_t key[AES_BLOCK_SIZE * 2]);
-int aes_encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *key, unsigned int keybits,
+int aes_encrypt(const unsigned char *plaintext, int plaintext_len, const unsigned char *key, unsigned int keybits,
                 unsigned char iv[16], unsigned char *ciphertext, int ciphertext_len);
-int aes_decrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *key, unsigned int keybits,
+int aes_decrypt(const unsigned char *ciphertext, int ciphertext_len, const unsigned char *key, unsigned int keybits,
                 unsigned char iv[16], unsigned char *plaintext, int plaintext_len);
 
 #ifdef __cplusplus

--- a/utils/serializer.c
+++ b/utils/serializer.c
@@ -14,7 +14,8 @@
 #define IV_LEN 16
 #define UINT32_LEN 10
 
-int serialize_msg(uint8_t *iv, uint32_t ciphertext_len, uint8_t *ciphertext, char *out_msg, uint32_t *out_msg_len) {
+int serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const uint8_t *ciphertext, char *out_msg,
+                  uint32_t *out_msg_len) {
   char str_ciphertext_len[UINT32_LEN + 1] = {};
   char *ptr = out_msg;
 
@@ -36,12 +37,12 @@ int serialize_msg(uint8_t *iv, uint32_t ciphertext_len, uint8_t *ciphertext, cha
   return 0;
 }
 
-int deserialize_msg(char *msg, uint8_t *iv, uint32_t *ciphertext_len, uint8_t *ciphertext) {
+int deserialize_msg(char *msg, const uint8_t *iv, uint32_t *ciphertext_len, uint8_t *ciphertext) {
   char str_ciphertext_len[UINT32_LEN + 1] = {};
   char *ptr = msg;
   uint32_t ciphertext_len_tmp;
 
-  memcpy(iv, ptr, IV_LEN);
+  memcpy((char *)iv, ptr, IV_LEN);
   ptr += IV_LEN;
 
   memcpy(str_ciphertext_len, ptr, UINT32_LEN);

--- a/utils/serializer.h
+++ b/utils/serializer.h
@@ -15,8 +15,9 @@
 extern "C" {
 #endif
 
-int serialize_msg(uint8_t *iv, uint32_t ciphertext_len, uint8_t *ciphertext, char *out_msg, uint32_t *out_msg_len);
-int deserialize_msg(char *msg, uint8_t *iv, uint32_t *ciphertext_len, uint8_t *ciphertext);
+int serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const uint8_t *ciphertext, char *out_msg,
+                  uint32_t *out_msg_len);
+int deserialize_msg(char *msg, const uint8_t *iv, uint32_t *ciphertext_len, uint8_t *ciphertext);
 
 #ifdef __cplusplus
 }

--- a/utils/uart_utils.c
+++ b/utils/uart_utils.c
@@ -50,24 +50,9 @@ static int set_interface_attribs(int fd, int speed) {
   return 0;
 }
 
-static void set_mincount(int fd, int mcount) {
-  struct termios tty;
-
-  if (tcgetattr(fd, &tty) < 0) {
-    printf("Error tcgetattr: %s\n", strerror(errno));
-    return;
-  }
-
-  tty.c_cc[VMIN] = mcount ? 1 : 0;
-  tty.c_cc[VTIME] = 5; /* half second timer */
-
-  if (tcsetattr(fd, TCSANOW, &tty) < 0) printf("Error tcsetattr: %s\n", strerror(errno));
-}
-
 int uart_init() {
   char *portname = "/dev/ttyHS0";
   int fd;
-  int wlen;
 
   fd = open(portname, O_RDWR | O_NOCTTY | O_SYNC);
   if (fd < 0) {
@@ -76,7 +61,6 @@ int uart_init() {
   }
   /*baudrate 115200, 8 bits, no parity, 1 stop bit */
   set_interface_attribs(fd, B115200);
-  // set_mincount(fd, 0);                /* set to pure timed read */
 
   return fd;
 }
@@ -99,7 +83,7 @@ char *uart_read(const int fd) {
   if (rdlen > 0) {
     // printf("buf = %s\n", buf);
     response = (char *)malloc(sizeof(char) * rdlen);
-    strncpy(response, buf, READ_BUFFER_SIZE);
+    strncpy(response, (char *)buf, READ_BUFFER_SIZE);
   } else if (rdlen < 0) {
     printf("Error from read: %ld: %s\n", rdlen, strerror(errno));
   }


### PR DESCRIPTION
This commit did the following things:

Fix no return values warning from `http_send_request` and
`http_read_response`.

Remove duplicate const warning inside `http_send_request` declaration.

Fix type warning from ciphertext, iv, raw_msg.

Add const to inform user the data which pointed should not be changed.

Remove unused function `set_mincount`.

Remove unused variable.