### PR TITLE
refactor: Unify error return code

### DIFF
--- a/connectivity/conn_http.c
+++ b/connectivity/conn_http.c
@@ -20,8 +20,8 @@ void mbedtls_debug(void *ctx, int level, const char *file, int line, const char 
   fflush((FILE *)ctx);
 }
 
-http_retcode_t http_open(connect_info_t *const info, char const *const seed_nonce, char const *const host,
-                         char const *const port) {
+retcode_t http_open(connect_info_t *const info, char const *const seed_nonce, char const *const host,
+                    char const *const port) {
   int ret;
 
   if (info->https) {
@@ -115,7 +115,8 @@ http_retcode_t http_open(connect_info_t *const info, char const *const seed_nonc
   return RET_OK;
 }
 
-http_retcode_t http_send_request(connect_info_t *const info, const char *req) {
+retcode_t http_send_request(connect_info_t *const info, const char const *req) {
+  retcode_t ret;
   size_t req_len = strlen(req), write_len = 0, ret_len;
 
   while (write_len < req_len) {
@@ -135,7 +136,7 @@ http_retcode_t http_send_request(connect_info_t *const info, const char *req) {
   return RET_OK;
 }
 
-http_retcode_t http_read_response(connect_info_t *const info, char *res, size_t res_len) {
+retcode_t http_read_response(connect_info_t *const info, char *res, size_t res_len) {
   size_t ret_len;
   const uint32_t timeout_period = 5000;  // in milliseconds
 
@@ -160,7 +161,7 @@ http_retcode_t http_read_response(connect_info_t *const info, char *res, size_t 
   return RET_OK;
 }
 
-http_retcode_t http_close(connect_info_t *const info) {
+retcode_t http_close(connect_info_t *const info) {
   if (info->https) {
     mbedtls_ssl_close_notify(info->ssl_ctx);
 
@@ -184,8 +185,8 @@ http_retcode_t http_close(connect_info_t *const info) {
   return RET_OK;
 }
 
-http_retcode_t set_post_request(char const *const api, char const *const host, const uint32_t port,
-                                char const *const req_body, char **out) {
+retcode_t set_post_request(char const *const api, char const *const host, const uint32_t port,
+                           char const *const req_body, char **out) {
   const char post_req_format[] =
       "POST /%s HTTP/1.1\r\n"
       "Host: %s:%d\r\n"
@@ -206,7 +207,7 @@ http_retcode_t set_post_request(char const *const api, char const *const host, c
   return RET_OK;
 }
 
-http_retcode_t set_get_request(char const *const api, char const *const host, const uint32_t port, char **out) {
+retcode_t set_get_request(char const *const api, char const *const host, const uint32_t port, char **out) {
   const char get_req_format[] =
       "GET /%s HTTP/1.1\r\n"
       "Host: %s:%d\r\n"

--- a/connectivity/conn_http.h
+++ b/connectivity/conn_http.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file
@@ -38,15 +38,15 @@ typedef struct {
   mbedtls_x509_crt *cacert;
 } connect_info_t;
 
-http_retcode_t http_open(connect_info_t *const info, char const *const seed_nonce, char const *const host,
-                         char const *const port);
-http_retcode_t http_send_request(connect_info_t *const info, const char *req);
-http_retcode_t http_read_response(connect_info_t *const info, char *res, size_t res_len);
-http_retcode_t http_close(connect_info_t *const info);
+retcode_t http_open(connect_info_t *const info, char const *const seed_nonce, char const *const host,
+                    char const *const port);
+retcode_t http_send_request(connect_info_t *const info, const char const *req);
+retcode_t http_read_response(connect_info_t *const info, char *res, size_t res_len);
+retcode_t http_close(connect_info_t *const info);
 
-http_retcode_t set_post_request(char const *const api, char const *const host, const uint32_t port,
-                                char const *const req_body, char **out);
-http_retcode_t set_get_request(char const *const api, char const *const host, const uint32_t port, char **out);
+retcode_t set_post_request(char const *const api, char const *const host, const uint32_t port,
+                           char const *const req_body, char **out);
+retcode_t set_get_request(char const *const api, char const *const host, const uint32_t port, char **out);
 
 int parser_body_callback(http_parser *parser, const char *at, size_t length);
 

--- a/utils/defined_error.h
+++ b/utils/defined_error.h
@@ -23,7 +23,7 @@ typedef enum {
   RET_HTTP_CERT,
   RET_HTTP_CONNECT,
   RET_HTTP_SSL,
-} http_retcode_t;
+} retcode_t;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
These commits fixed the following things:
Renmae `http_retcode_t` to `retcode_t` for general error and status coverage.
Add new status code inside `utils/defined_error.h` if you needed.

closes #37