### PR TITLE
Bump copyright date for each source

### DIFF
--- a/tests/test_crypto_utils.c
+++ b/tests/test_crypto_utils.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/test_serializer.c
+++ b/tests/test_serializer.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/test_tryte_byte_conv.c
+++ b/tests/test_tryte_byte_conv.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
 #include "stdio.h"
 #include "string.h"
 #include "tryte_byte_conv.h"

--- a/utils/defined_error.h
+++ b/utils/defined_error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file

--- a/utils/serializer.c
+++ b/utils/serializer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file

--- a/utils/serializer.h
+++ b/utils/serializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file

--- a/utils/tryte_byte_conv.c
+++ b/utils/tryte_byte_conv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file

--- a/utils/tryte_byte_conv.h
+++ b/utils/tryte_byte_conv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file


### PR DESCRIPTION
Update copyright from 2019 to 2019-2020.
Add copyright license if it wasn't included in header file.

close #38 