### PR TITLE
refactor: Remove unused build flag

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,11 +1,4 @@
 OBJS = crypto_utils.o serializer.o tryte_byte_conv.o uart_utils.o
-
-ifeq ($(KEY_DEBUG), n)
-UTILS_CFLAGS = $(CFLAGS)
-else
-UTILS_CFLAGS = $(CFLAGS) -DKEY_DEBUG
-endif
-
 all: $(OBJS)
 
 %.o: %.c


### PR DESCRIPTION
KEY_DEBUG debug flag was deprecated. Use DEBUG for debug flag.