### PR TITLE
feat: Promote send-via-https as generic utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,9 @@ INCLUDES = -I$(THIRD_PARTY_PATH)/http-parser -I$(MBEDTLS_PATH)/include -I$(ROOT_
 LIBS = $(MBEDTLS_PATH)/library/libmbedx509.a $(MBEDTLS_PATH)/library/libmbedtls.a $(MBEDTLS_PATH)/library/libmbedcrypto.a
 export INCLUDES
 
-UTILS_OBJS = $(UTILS_PATH)/crypto_utils.o $(UTILS_PATH)/serializer.o $(UTILS_PATH)/tryte_byte_conv.o $(UTILS_PATH)/uart_utils.o
-# We need to modify this rule here to be compatible to the situation 
+UTILS_OBJS = $(UTILS_PATH)/crypto_utils.o $(UTILS_PATH)/serializer.o $(UTILS_PATH)/tryte_byte_conv.o \
+			 $(UTILS_PATH)/uart_utils.o $(UTILS_PATH)/protocol.o
+# We need to modify this rule here to be compatible to the situation
 # that we have several different ways of connectivity in the future
 CONNECTIVITY_OBJS = conn_http.o
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,8 +1,8 @@
-OBJS = crypto_utils.o serializer.o tryte_byte_conv.o uart_utils.o
+OBJS = crypto_utils.o serializer.o tryte_byte_conv.o uart_utils.o protocol.o
 all: $(OBJS)
 
 %.o: %.c
-	$(CC) -c $(UTILS_CFLAGS) $(INCLUDES) -o $@ $^
+	$(CC) -c $(CFLAGS) $(INCLUDES) -o $@ $^
 
 clean:
 	rm -f *.o

--- a/utils/protocol.c
+++ b/utils/protocol.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "protocol.h"
+#include <stdlib.h>
+#include <string.h>
+#include "conn_http.h"
+#include "defined_error.h"
+#include "http_parser.h"
+
+static http_parser parser;
+
+retcode_t send_https_msg(char const *host, char const *port, char const *api, const char *msg, const int msg_len,
+                         const char *ssl_seed) {
+  char res[4096] = {0};
+  char *req = NULL;
+  retcode_t ret = RET_OK;
+
+  set_post_request(api, host, atoi(port), msg, &req);
+  http_parser_settings settings;
+  settings.on_body = parser_body_callback;
+
+  connect_info_t info = {.https = true};
+  http_open(&info, ssl_seed, host, port);
+  http_send_request(&info, req);
+  http_read_response(&info, res, sizeof(res) / sizeof(char));
+  http_close(&info);
+  http_parser_init(&parser, HTTP_RESPONSE);
+  http_parser_execute(&parser, &settings, res, strlen(res));
+#ifdef DEBUG
+  printf("HTTP Response: %s\n", http_res_body);
+#endif
+  free(http_res_body);
+  http_res_body = NULL;
+
+  ret = parser.status_code;
+  free(req);
+  return ret;
+}

--- a/utils/protocol.h
+++ b/utils/protocol.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#ifndef UTILS_PROTOCOL_H
+#define UTILS_PROTOCOL_H
+
+#include "defined_error.h"
+
+/**
+ * @brief Send message via http protocol
+ *
+ * @param[in] host Https host
+ * @param[in] port Https port
+ * @param[in] api API for post request to https server, example: transaction/. Must be
+ * string.
+ * @param[in] msg Message to send
+ * @param[in] msg_len Length of message
+ * @param[in] ssl_seed Seed for ssl connection
+ *
+ * @return #retcode_t
+ */
+retcode_t send_https_msg(char const *host, char const *port, char const *api, const char *msg, const int msg_len,
+                         const char *ssl_seed);
+#endif  // UTILS_PROTOCOL_H


### PR DESCRIPTION
Defining `send_http_msg()` inside `main.c` may cause us hard to intergrate with legato or implement unit-test. A new file `url.h` is added, it includes HTTPS protocol implementation.

Change `send_http_msg()` prototype for sending general message instead of restricting format.
    
Closes #49
