### PR TITLE
feat: Promote random tryte generation as generic utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,7 @@ LIBS = $(MBEDTLS_PATH)/library/libmbedx509.a $(MBEDTLS_PATH)/library/libmbedtls.
 export INCLUDES
 
 UTILS_OBJS = $(UTILS_PATH)/crypto_utils.o $(UTILS_PATH)/serializer.o $(UTILS_PATH)/tryte_byte_conv.o \
-			 $(UTILS_PATH)/uart_utils.o $(UTILS_PATH)/protocol.o
-# We need to modify this rule here to be compatible to the situation
+			 $(UTILS_PATH)/uart_utils.o $(UTILS_PATH)/protocol.o $(UTILS_PATH)/trytes.o
 # that we have several different ways of connectivity in the future
 CONNECTIVITY_OBJS = conn_http.o
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,4 +1,4 @@
-OBJS = crypto_utils.o serializer.o tryte_byte_conv.o uart_utils.o protocol.o
+OBJS = crypto_utils.o serializer.o tryte_byte_conv.o uart_utils.o protocol.o trytes.o
 all: $(OBJS)
 
 %.o: %.c

--- a/utils/trytes.c
+++ b/utils/trytes.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#include "trytes.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define REQ_BODY                                                           \
+  "{\"value\": 0, \"tag\": \"POWEREDBYTANGLEACCELERATOR9\", \"message\": " \
+  "\"%s\", \"address\":\"%s\"}\r\n\r\n"
+
+void gen_rand_trytes(const uint16_t len, uint8_t *out) {
+  const char tryte_alphabet[] = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const int alphabet_array_length = sizeof(tryte_alphabet) / sizeof(char);
+  for (int i = 0; i < len; i++) {
+    uint8_t rand_index = rand() % alphabet_array_length;
+    out[i] = tryte_alphabet[rand_index];
+  }
+}
+
+void gen_trytes_message(const char *tryte_msg, const uint8_t *addr, char req_body[1024]) {
+  memset(req_body, 0, sizeof(char) * 1024);
+  snprintf(req_body, 1024, REQ_BODY, tryte_msg, addr);
+}

--- a/utils/trytes.h
+++ b/utils/trytes.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
+#ifndef TRYTE_MSG_H
+#define TRYTE_MSG_H
+
+#include <stdint.h>
+
+/**
+ * @brief Generate randomized trytes generation
+ *
+ * @param[in] len Length of output
+ * @param[out] out The pointer to output array
+ */
+void gen_rand_trytes(const uint16_t len, uint8_t *out);
+
+/**
+ * @brief create unify message to send to tangle accerlator
+ *
+ * @param[in] tryte_msg Byte message which has converted to tryte
+ * @param[in] addr IOTA next address
+ * @param[out] req_body[1024] Message array
+ */
+void gen_trytes_message(const char *tryte_msg, const uint8_t *addr, char req_body[1024]);
+
+#endif  // TRYTE_MSG_H


### PR DESCRIPTION
Defining gen_tryte() inside main.c may cause us hard to integrate with legato or implement unit-test. A new file tryte_msg.h is added, it includes for tryte message related implementation.

Add gen_trytres_message() for generate unify trytes message for logger and https sender.

Closes #50