### PR TITLE
fix: Bump copyright date for each source

### DIFF
--- a/connectivity/ca_cert.h
+++ b/connectivity/ca_cert.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
 #define ca_crt_rsa_size 70369
 
 char ca_crt_rsa[70369] = {

--- a/connectivity/conn_http.c
+++ b/connectivity/conn_http.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
 #include <errno.h>
 #include <netdb.h>
 #include <signal.h>

--- a/main.c
+++ b/main.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/utils/crypto_utils.c
+++ b/utils/crypto_utils.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
+ * All Rights Reserved.
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the MIT license. A copy of the license can be found in the file
+ * "LICENSE" at the root of this distribution.
+ */
+
 #include "crypto_utils.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/utils/crypto_utils.h
+++ b/utils/crypto_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 BiiLabs Co., Ltd. and Contributors
+ * Copyright (C) 2019-2020 BiiLabs Co., Ltd. and Contributors
  * All Rights Reserved.
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the MIT license. A copy of the license can be found in the file


### PR DESCRIPTION
Add copyright license if it wasn't included in header file.

Closes #55