### PR TITLE
fix: Eliminate compilation warnings

### DIFF
--- a/connectivity/conn_http.c
+++ b/connectivity/conn_http.c
@@ -115,8 +115,7 @@ retcode_t http_open(connect_info_t *const info, char const *const seed_nonce, ch
   return RET_OK;
 }
 
-retcode_t http_send_request(connect_info_t *const info, const char const *req) {
-  retcode_t ret;
+retcode_t http_send_request(connect_info_t *const info, const char *req) {
   size_t req_len = strlen(req), write_len = 0, ret_len;
 
   while (write_len < req_len) {

--- a/connectivity/conn_http.h
+++ b/connectivity/conn_http.h
@@ -40,7 +40,7 @@ typedef struct {
 
 retcode_t http_open(connect_info_t *const info, char const *const seed_nonce, char const *const host,
                     char const *const port);
-retcode_t http_send_request(connect_info_t *const info, const char const *req);
+retcode_t http_send_request(connect_info_t *const info, const char *req);
 retcode_t http_read_response(connect_info_t *const info, char *res, size_t res_len);
 retcode_t http_close(connect_info_t *const info);
 


### PR DESCRIPTION
Eliminate duplicated const declaration specifier warning from gcc
during compiling. `req` pointer is for read only, recommend to remove
redundant const specifier.