### PR TITLE
refactor: Reduce duplicated variable defined

### DIFF
--- a/connectivity/Makefile
+++ b/connectivity/Makefile
@@ -1,5 +1,3 @@
-INCLUDES := -I$(THIRD_PARTY_PATH)/mbedtls/include -I$(THIRD_PARTY_PATH)/http-parser -I$(ROOT_DIR)/utils
-
 all: conn_http.o
 
 .NOTPARALLEL:


### PR DESCRIPTION
`INCLUDES` flag was defined inside major Makefile. So I remove
duplicated variable.