### PR TITLE
Eliminate compilation warnings

### DIFF
--- a/connectivity/conn_http.c
+++ b/connectivity/conn_http.c
@@ -115,8 +115,7 @@ retcode_t http_open(connect_info_t *const info, char const *const seed_nonce, ch
   return RET_OK;
 }
 
-retcode_t http_send_request(connect_info_t *const info, const char const *req) {
-  retcode_t ret;
+retcode_t http_send_request(connect_info_t *const info, const char *req) {
   size_t req_len = strlen(req), write_len = 0, ret_len;
 
   while (write_len < req_len) {

--- a/connectivity/conn_http.h
+++ b/connectivity/conn_http.h
@@ -40,7 +40,7 @@ typedef struct {
 
 retcode_t http_open(connect_info_t *const info, char const *const seed_nonce, char const *const host,
                     char const *const port);
-retcode_t http_send_request(connect_info_t *const info, const char const *req);
+retcode_t http_send_request(connect_info_t *const info, const char *req);
 retcode_t http_read_response(connect_info_t *const info, char *res, size_t res_len);
 retcode_t http_close(connect_info_t *const info);
 

--- a/main.c
+++ b/main.c
@@ -87,9 +87,10 @@ int log_address(char *next_addr) {
 }
 
 int main(int argc, char *argv[]) {
-  uint8_t ciphertext[1024] = {0}, iv[16] = {0}, raw_msg[1000] = {0};
+  char tryte_msg[1024] = {0}, msg[1024] = {0}, addr[ADDR_LEN + 1] = ADDRESS, next_addr[ADDR_LEN + 1] = {0},
+       ciphertext[1024] = {0}, raw_msg[1000] = {0};
   uint32_t raw_msg_len = 1 + ADDR_LEN + 20, ciphertext_len = 0, msg_len;
-  char tryte_msg[1024] = {0}, msg[1024] = {0}, addr[ADDR_LEN + 1] = ADDRESS, next_addr[ADDR_LEN + 1] = {0};
+  uint8_t iv[AES_BLOCK_SIZE] = {0};
   srand(time(NULL));
 
 #ifndef DEBUG

--- a/utils/crypto_utils.c
+++ b/utils/crypto_utils.c
@@ -66,8 +66,8 @@ int get_aes_key(const uint8_t *key) {
   return 0;
 }
 
-int aes_encrypt(const unsigned char *plaintext, int plaintext_len, const unsigned char *key, unsigned int keybits,
-                unsigned char iv[AES_BLOCK_SIZE], unsigned char *ciphertext, int ciphertext_len) {
+int aes_encrypt(const char *plaintext, int plaintext_len, const unsigned char *key, unsigned int keybits,
+                unsigned char iv[AES_BLOCK_SIZE], char *ciphertext, int ciphertext_len) {
   mbedtls_aes_context ctx;
   int status;
   unsigned char buf[AES_BLOCK_SIZE];
@@ -114,8 +114,8 @@ exit:
   return -1;
 }
 
-int aes_decrypt(const unsigned char *ciphertext, int ciphertext_len, const unsigned char *key, unsigned int keybits,
-                unsigned char iv[AES_BLOCK_SIZE], unsigned char *plaintext, int plaintext_len) {
+int aes_decrypt(const char *ciphertext, int ciphertext_len, const unsigned char *key, unsigned int keybits,
+                unsigned char iv[AES_BLOCK_SIZE], char *plaintext, int plaintext_len) {
   mbedtls_aes_context ctx;
   int status, n = 0;
   char *err;
@@ -155,8 +155,8 @@ exit:
   return -1;
 }
 
-int encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *ciphertext, int ciphertext_len,
-            uint8_t iv[AES_BLOCK_SIZE], uint8_t key[AES_BLOCK_SIZE * 2], uint8_t device_id[IMSI_LEN + 1]) {
+int encrypt(const char *plaintext, int plaintext_len, char *ciphertext, int ciphertext_len, uint8_t iv[AES_BLOCK_SIZE],
+            uint8_t key[AES_CBC_KEY_SIZE], uint8_t device_id[IMSI_LEN + 1]) {
   int new_len = 0;
   char *err = NULL;
   uint8_t tmp[AES_BLOCK_SIZE];
@@ -206,8 +206,7 @@ exit:
   return new_len;
 }
 
-int decrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *plaintext, int plaintext_len,
-            uint8_t iv[AES_BLOCK_SIZE], uint8_t key[AES_BLOCK_SIZE * 2]) {
-  aes_decrypt(ciphertext, ciphertext_len, key, 256, iv, plaintext, plaintext_len);
-  return 0;
+int decrypt(const char *ciphertext, int ciphertext_len, char *plaintext, int plaintext_len, uint8_t iv[AES_BLOCK_SIZE],
+            uint8_t key[AES_CBC_KEY_SIZE]) {
+  return aes_decrypt(ciphertext, ciphertext_len, key, 256, iv, plaintext, plaintext_len);
 }

--- a/utils/crypto_utils.h
+++ b/utils/crypto_utils.h
@@ -16,19 +16,20 @@ extern "C" {
 #endif
 
 #define AES_BLOCK_SIZE 16
+#define AES_CBC_KEY_SIZE AES_BLOCK_SIZE * 2
 #define MAXLINE 1024
 #define IMSI_LEN 15
 
 int get_device_id(const char *device_id);
 int get_aes_key(const uint8_t *key);
-int encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *ciphertext, int ciphertext_len, uint8_t iv[16],
-            uint8_t key[AES_BLOCK_SIZE * 2], uint8_t device_id[IMSI_LEN + 1]);
-int decrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *plaintext, int plaintext_len, uint8_t iv[16],
-            uint8_t key[AES_BLOCK_SIZE * 2]);
-int aes_encrypt(const unsigned char *plaintext, int plaintext_len, const unsigned char *key, unsigned int keybits,
-                unsigned char iv[16], unsigned char *ciphertext, int ciphertext_len);
-int aes_decrypt(const unsigned char *ciphertext, int ciphertext_len, const unsigned char *key, unsigned int keybits,
-                unsigned char iv[16], unsigned char *plaintext, int plaintext_len);
+int encrypt(const char *plaintext, int plaintext_len, char *ciphertext, int ciphertext_len, uint8_t iv[AES_BLOCK_SIZE],
+            uint8_t key[AES_CBC_KEY_SIZE], uint8_t device_id[IMSI_LEN + 1]);
+int decrypt(const char *ciphertext, int ciphertext_len, char *plaintext, int plaintext_len, uint8_t iv[AES_BLOCK_SIZE],
+            uint8_t key[AES_CBC_KEY_SIZE]);
+int aes_encrypt(const char *plaintext, int plaintext_len, const unsigned char *key, unsigned int keybits,
+                unsigned char iv[AES_BLOCK_SIZE], char *ciphertext, int ciphertext_len);
+int aes_decrypt(const char *ciphertext, int ciphertext_len, const unsigned char *key, unsigned int keybits,
+                unsigned char iv[AES_BLOCK_SIZE], char *plaintext, int plaintext_len);
 
 #ifdef __cplusplus
 }

--- a/utils/serializer.c
+++ b/utils/serializer.c
@@ -14,7 +14,7 @@
 #define IV_LEN 16
 #define UINT32_LEN 10
 
-int serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const uint8_t *ciphertext, char *out_msg,
+int serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const char *ciphertext, char *out_msg,
                   uint32_t *out_msg_len) {
   char str_ciphertext_len[UINT32_LEN + 1] = {};
   char *ptr = out_msg;
@@ -37,7 +37,7 @@ int serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const uint8_t *cip
   return 0;
 }
 
-int deserialize_msg(char *msg, const uint8_t *iv, uint32_t *ciphertext_len, uint8_t *ciphertext) {
+int deserialize_msg(char *msg, const uint8_t *iv, uint32_t *ciphertext_len, char *ciphertext) {
   char str_ciphertext_len[UINT32_LEN + 1] = {};
   char *ptr = msg;
   uint32_t ciphertext_len_tmp;

--- a/utils/serializer.h
+++ b/utils/serializer.h
@@ -15,9 +15,9 @@
 extern "C" {
 #endif
 
-int serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const uint8_t *ciphertext, char *out_msg,
+int serialize_msg(const uint8_t *iv, uint32_t ciphertext_len, const char *ciphertext, char *out_msg,
                   uint32_t *out_msg_len);
-int deserialize_msg(char *msg, const uint8_t *iv, uint32_t *ciphertext_len, uint8_t *ciphertext);
+int deserialize_msg(char *msg, const uint8_t *iv, uint32_t *ciphertext_len, char *ciphertext);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
gcc-9 shows a harmless warning from conn_http:
```
connectivity/conn_http.c:118:68: warning: duplicate ‘const’ declaration specifier [-Wduplicate-decl-specifier]
  118 | retcode_t http_send_request(connect_info_t *const info, const char const *req) {
      |                                                                                                                                                   ^~~~~
```
Remove one of the specifiers give as the expectd behavior.

Fix const qualifier warning and pointer signedness warning from
test_crypto_utils and main function. Inside test_crypto_utils.c we define
text test data as constant char* type, we should unify them.

Closes #51
