### PR TITLE
fix: Eliminate global variable

### DIFF
--- a/connectivity/conn_http.c
+++ b/connectivity/conn_http.c
@@ -231,6 +231,8 @@ retcode_t set_get_request(char const *const path, char const *const host, const 
 }
 
 int parser_body_callback(http_parser *parser, const char *at, size_t length) {
-  http_res_body = strdup(at);
+#ifdef DEBUG
+  printf("HTTP Response: %s\n", at);
+#endif
   return 0;
 }

--- a/connectivity/conn_http.h
+++ b/connectivity/conn_http.h
@@ -23,11 +23,6 @@ extern "C" {
 #include "mbedtls/net.h"
 #include "mbedtls/ssl.h"
 
-/**< FIXME:A global pointer that points to HTTP resource body for passing response body to http_parser.
- * This variable will be removed or changed to static pointer as soon as possible. Don't
- * use this pointer directly.*/
-char *http_res_body;
-
 typedef struct {
   bool https;                         /**< Flag for check info has initialized or not */
   mbedtls_net_context *net_ctx;       /**< mbedtls_next context                       */

--- a/utils/protocol.c
+++ b/utils/protocol.c
@@ -32,11 +32,6 @@ retcode_t send_https_msg(char const *host, char const *port, char const *api, co
   http_close(&info);
   http_parser_init(&parser, HTTP_RESPONSE);
   http_parser_execute(&parser, &settings, res, strlen(res));
-#ifdef DEBUG
-  printf("HTTP Response: %s\n", http_res_body);
-#endif
-  free(http_res_body);
-  http_res_body = NULL;
 
   ret = parser.status_code;
   free(req);


### PR DESCRIPTION
The `http_res_body` is a global pointer for printing debug
message inside send_http_msg. The pointer can be reduced and print the
debug message inside callback function.

closes #62