### PR TITLE
fix: Consistent parameters order

### DIFF
--- a/main.c
+++ b/main.c
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
   memcpy(private_key, key, 16);
   memcpy(iv, iv_global, 16);
 #endif
-      ciphertext_len = encrypt(raw_msg, strlen((char *)raw_msg), ciphertext, MAX_MSG_LEN, iv, private_key, id);
+      ciphertext_len = encrypt(raw_msg, strlen((char *)raw_msg), private_key, id, iv, ciphertext, MAX_MSG_LEN);
       if (ciphertext_len == 0) {
         fprintf(stderr, "%s\n", "encrypt msg error");
         return -1;

--- a/tests/test_crypto_utils.c
+++ b/tests/test_crypto_utils.c
@@ -80,8 +80,8 @@ void test_wrapper(void) {
   memcpy(iv, iv_global, AES_BLOCK_SIZE);
 #endif
 
-  ciphertext_len = encrypt((char*)test_payload2, test_paylen2, ciphertext, MAXLINE, iv, private_key, id);
-  decrypt(ciphertext, ciphertext_len, plain, MAXLINE, iv, private_key);
+  ciphertext_len = encrypt((char*)test_payload2, test_paylen2, private_key, id, iv, ciphertext, MAXLINE);
+  decrypt(ciphertext, ciphertext_len, private_key, iv, plain, MAXLINE);
 
   /* compare payload */
   TEST_ASSERT_EQUAL_UINT8_ARRAY(test_payload2, plain, test_paylen2);

--- a/utils/crypto_utils.c
+++ b/utils/crypto_utils.c
@@ -105,8 +105,8 @@ exit:
   return -1;
 }
 
-int encrypt(const char *plaintext, int plaintext_len, char *ciphertext, int ciphertext_len, uint8_t iv[AES_BLOCK_SIZE],
-            uint8_t key[AES_CBC_KEY_SIZE], uint8_t device_id[IMSI_LEN + 1]) {
+int encrypt(const char *plaintext, int plaintext_len, uint8_t key[AES_CBC_KEY_SIZE], uint8_t device_id[IMSI_LEN + 1],
+            uint8_t iv[AES_BLOCK_SIZE], char *ciphertext, int ciphertext_len) {
   int new_len = 0;
   char *err = NULL;
   uint8_t tmp[AES_BLOCK_SIZE];
@@ -156,7 +156,7 @@ exit:
   return new_len;
 }
 
-retcode_t decrypt(const char *ciphertext, int ciphertext_len, char *plaintext, int plaintext_len,
-                  uint8_t iv[AES_BLOCK_SIZE], uint8_t key[AES_CBC_KEY_SIZE]) {
+retcode_t decrypt(const char *ciphertext, int ciphertext_len, uint8_t key[AES_CBC_KEY_SIZE], uint8_t iv[AES_BLOCK_SIZE],
+                  char *plaintext, int plaintext_len) {
   return aes_decrypt(ciphertext, ciphertext_len, key, 256, iv, plaintext, plaintext_len);
 }

--- a/utils/crypto_utils.h
+++ b/utils/crypto_utils.h
@@ -26,33 +26,33 @@ extern "C" {
  *
  * @param[in] plaintext The text to be encrypted
  * @param[in] plaintext_len Plaintext length
- * @param[out] ciphertext Ciphrtext
- * @param[in] ciphertext_len Ciphertext length
- * @param[in, out] iv[AES_BLOCK_SIZE] Initialization vector
  * @param[in] key[AES_CBC_KEY_SIZE] Encryption key
  * @param[in] device_id[IMSI_LEN + 1] Device id
+ * @param[in, out] iv[AES_BLOCK_SIZE] Initialization vector
+ * @param[out] ciphertext Ciphrtext
+ * @param[in] ciphertext_len Ciphertext length
  *
  * @return
  * - Ciphertext text new length on success
  * - 0 on error
  */
-int encrypt(const char *plaintext, int plaintext_len, char *ciphertext, int ciphertext_len, uint8_t iv[AES_BLOCK_SIZE],
-            uint8_t key[AES_CBC_KEY_SIZE], uint8_t device_id[IMSI_LEN + 1]);
+int encrypt(const char *plaintext, int plaintext_len, uint8_t key[AES_CBC_KEY_SIZE], uint8_t device_id[IMSI_LEN + 1],
+            uint8_t iv[AES_BLOCK_SIZE], char *ciphertext, int ciphertext_len);
 
 /**
  * @brief Decrypt ciphertext
  *
  * @param[in] ciphertext Ciphertext
  * @param[in] ciphertext_len Ciphertext length
+ * @param[in] key[AES_CBC_KEY_SIZE] Decryption key
+ * @param[in] iv[AES_BLOCK_SIZE] Initialization vector
  * @param[out] plaintext Plaintext
  * @param[in] plaintext_len Plaintext length
- * @param[in] iv[AES_BLOCK_SIZE] Initialization vector
- * @param[in] key[AES_CBC_KEY_SIZE] Decryption key
  *
  * @return #retcode_t
  */
-retcode_t decrypt(const char *ciphertext, int ciphertext_len, char *plaintext, int plaintext_len,
-                  uint8_t iv[AES_BLOCK_SIZE], uint8_t key[AES_CBC_KEY_SIZE]);
+retcode_t decrypt(const char *ciphertext, int ciphertext_len, uint8_t key[AES_CBC_KEY_SIZE], uint8_t iv[AES_BLOCK_SIZE],
+                  char *plaintext, int plaintext_len);
 
 /**
  * @brief Implementation of AES encryption algorithm


### PR DESCRIPTION
The order of output parameters before input parameters may make
user misleading. This commit move the order of output parameters
behind input parameters.

closes #54