### PR TITLE
fix: Change accelerator host in favor of consolidated service endpoint

### DIFF
--- a/main.c
+++ b/main.c
@@ -19,7 +19,7 @@
 #include "utils/trytes.h"
 #include "utils/uart_utils.h"
 
-#define HOST "tangle-accel.puyuma.org"
+#define HOST "tangle-accel.biilabs.io"
 #define PORT "443"
 #define API "transaction/"
 #define SSL_SEED "nonce"


### PR DESCRIPTION
The tangle-accelerator host is outdated. This commit updates the
old host to the new host.
closes #70